### PR TITLE
Update Neon Devnet & Add Neon Mainnet

### DIFF
--- a/Shared/Ethereum/EthereumChain.swift
+++ b/Shared/Ethereum/EthereumChain.swift
@@ -13,6 +13,7 @@ enum EthereumChain: Int {
     case fantomOpera = 250
     case celo = 42220
     case aurora = 1313161554
+    case neon = 245022934
     
     // Testnets
     case arbitrumRinkeby = 421611
@@ -45,7 +46,7 @@ enum EthereumChain: Int {
         }
     }
     
-    static let allMainnets: [EthereumChain] = [.ethereum, .polygon, .optimism, .binance, .arbitrum, .avalanche, .gnosisChain, .fantomOpera, .celo, .aurora]
+    static let allMainnets: [EthereumChain] = [.ethereum, .polygon, .optimism, .binance, .arbitrum, .avalanche, .gnosisChain, .fantomOpera, .celo, .aurora, .neon]
     static let allTestnets: [EthereumChain] = [.ethereumRopsten, .ethereumKovan, .ethereumRinkeby, .ethereumGoerli, .optimisticKovan, .arbitrumKovan, .arbitrumRinkeby, .polygonMumbai, .binanceTestnet, .avalancheFuji, .fantomTestnet, .neonDevnet]
     
     var name: String {
@@ -60,6 +61,7 @@ enum EthereumChain: Int {
         case .fantomOpera: return "Fantom Opera"
         case .celo: return "Celo"
         case .aurora: return "Aurora"
+        case .neon return "Neon"
             
         case .arbitrumRinkeby: return "Arbitrum Rinkeby"
         case .optimisticKovan: return "Optimistic Kovan"
@@ -92,7 +94,7 @@ enum EthereumChain: Int {
             return "FTM"
         case .celo:
             return "CELO"
-        case .neonDevnet:
+        case .neonDevnet, .neon:
             return "NEON"
         }
     }
@@ -122,6 +124,7 @@ enum EthereumChain: Int {
         case .fantomOpera: return "https://rpc.ftm.tools/"
         case .celo: return "https://rpc.ankr.com/celo"
         case .aurora: return "https://mainnet.aurora.dev"
+        case .neon return "https://neon-proxy-mainnet.solana.p2p.org/"
             
         case .arbitrumRinkeby: return "https://rinkeby.arbitrum.io/rpc"
         case .arbitrumKovan: return "https://kovan5.arbitrum.io/rpc"

--- a/Shared/Ethereum/EthereumChain.swift
+++ b/Shared/Ethereum/EthereumChain.swift
@@ -134,7 +134,7 @@ enum EthereumChain: Int {
         case .avalancheFuji: return "https://api.avax-test.network/ext/bc/C/rpc"
         case .polygonMumbai: return "https://polygon-mumbai.infura.io/v3/" + Secrets.infura
         case .fantomTestnet: return "https://rpc.testnet.fantom.network/"
-        case .neonDevnet: return "https://proxy.devnet.neonlabs.org/solana"
+        case .neonDevnet: return "https://devnet.neonevm.org/"
         }
     }
     


### PR DESCRIPTION
Hello team! Hope you're all doing well :)

This PR updates the RPC for Neon Devnet and adds Neon Mainnet which was finally released to public on 17th July during ETHCC!

References:
Mainnet: https://chainlist.org/chain/245022934
Devnet: https://chainlist.org/chain/245022926

Thanks!