### PR TITLE
Refactor helpers and fix defaults

### DIFF
--- a/Shared/Extensions/Bundle.swift
+++ b/Shared/Extensions/Bundle.swift
@@ -5,7 +5,7 @@ import Foundation
 extension Bundle {
 
     private enum Keys {
-        static let identifier = "CFBundleIdentifier"
+        static let identifier = "CFBundleIdentifierhmhmmhmh"
         static let name = "CFBundleName"
         static let shortVersionString = "CFBundleShortVersionString"
     }

--- a/Shared/Extensions/Bundle.swift
+++ b/Shared/Extensions/Bundle.swift
@@ -5,7 +5,7 @@ import Foundation
 extension Bundle {
 
     private enum Keys {
-        static let identifier = "CFBundleIdentifierhmhmmhmh"
+        static let identifier = "CFBundleIdentifier"
         static let name = "CFBundleName"
         static let shortVersionString = "CFBundleShortVersionString"
     }

--- a/Shared/Extensions/Bundle.swift
+++ b/Shared/Extensions/Bundle.swift
@@ -3,17 +3,23 @@
 import Foundation
 
 extension Bundle {
-    
+
+    private enum Keys {
+        static let identifier = "CFBundleIdentifier"
+        static let name = "CFBundleName"
+        static let shortVersionString = "CFBundleShortVersionString"
+    }
+
     var identifier: String {
-        return infoDictionary?["CFBundleIdentifier"] as? String ?? ""
+        infoDictionary?[Keys.identifier] as? String ?? ""
     }
-    
+
     var name: String {
-        return infoDictionary?["CFBundleName"] as? String ?? ""
+        infoDictionary?[Keys.name] as? String ?? ""
     }
-    
+
     var shortVersionString: String {
-        return infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        infoDictionary?[Keys.shortVersionString] as? String ?? ""
     }
     
 }

--- a/Shared/Extensions/Image.swift
+++ b/Shared/Extensions/Image.swift
@@ -7,7 +7,7 @@ extension Image {
     static var checkmark: Image { systemName("checkmark") }
     
     private static func systemName(_ systemName: String) -> Image {
-        return Image(systemName: systemName)
+        Image(systemName: systemName)
     }
     
 }

--- a/Shared/Extensions/String.swift
+++ b/Shared/Extensions/String.swift
@@ -9,19 +9,15 @@ extension String {
     
     var cleanEvenHex: String {
         let clean = cleanHex
-        if clean.count.isMultiple(of: 2) {
-            return clean
-        } else {
-            return String.zero + clean
-        }
+        return clean.count.isMultiple(of: 2) ? clean : String.zero + clean
     }
     
     var maybeJSON: Bool {
-        return hasPrefix("{") && hasSuffix("}") && count > 3
+        hasPrefix("{") && hasSuffix("}") && count > 3
     }
     
     var isOkAsPassword: Bool {
-        return count >= 4
+        count >= 4
     }
     
     var withFirstLetterCapitalized: String {
@@ -30,19 +26,15 @@ extension String {
     }
     
     var withEllipsis: String {
-        return self + "..."
+        self + "..."
     }
     
     var cleanHex: String {
-        if hasPrefix(String.hexPrefix) {
-            return String(dropFirst(2))
-        } else {
-            return self
-        }
+        hasPrefix(String.hexPrefix) ? String(dropFirst(2)) : self
     }
     
     var withHexPrefix: String {
-        return String.hexPrefix + self
+        String.hexPrefix + self
     }
     
     static func hex<T>(_ value: T, withPrefix: Bool = false) -> String where T : BinaryInteger {

--- a/Shared/Extensions/UserDefaults.swift
+++ b/Shared/Extensions/UserDefaults.swift
@@ -4,17 +4,14 @@ import Foundation
 
 extension UserDefaults {
     
-    func setCodable<T: Codable>(_ value: T, forKey: String) {
+    func setCodable<T: Codable>(_ value: T, forKey key: String) {
         let data = try? JSONEncoder().encode(value)
-        set(data, forKey: forKey)
+        set(data, forKey: key)
     }
 
-    func codableValue<T: Codable>(type: T.Type, forKey: String) -> T? {
-        guard let data = data(forKey: forKey),
-            let value = try? JSONDecoder().decode(type, from: data) else {
-            return nil
-        }
-        return value
+    func codableValue<T: Codable>(type: T.Type, forKey key: String) -> T? {
+        guard let data = data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
     }
     
 }

--- a/Shared/Services/Defaults.swift
+++ b/Shared/Services/Defaults.swift
@@ -6,39 +6,46 @@ struct Defaults {
  
     private static let userDefaults = UserDefaults.standard
 
+    private enum Keys {
+        static let walletsAndAccountsNames = "walletsAndAccountsNames"
+        static let latestReviewRequestDate = "latestReviewRequestDate"
+        static let reviewRequestsGoodMomentsCount = "reviewRequestsGoodMomentsCount"
+        static let isHiddenFromMenuBar = "isHiddenFromMenuBar"
+    }
+
     static var walletsAndAccountsNames: [String: String]? {
         get {
-            return userDefaults.value(forKey: "walletsAndAccountsNames") as? [String: String]
+            userDefaults.object(forKey: Keys.walletsAndAccountsNames) as? [String: String]
         }
         set {
-            userDefaults.set(newValue, forKey: "walletsAndAccountsNames")
+            userDefaults.set(newValue, forKey: Keys.walletsAndAccountsNames)
         }
     }
     
     static var latestReviewRequestDate: Date? {
         get {
-            return userDefaults.value(forKey: "latestReviewRequestDate") as? Date
+            userDefaults.object(forKey: Keys.latestReviewRequestDate) as? Date
         }
         set {
-            userDefaults.set(newValue, forKey: "latestReviewRequestDate")
+            userDefaults.set(newValue, forKey: Keys.latestReviewRequestDate)
         }
     }
     
     static var reviewRequestsGoodMomentsCount: Int {
         get {
-            return userDefaults.integer(forKey: "reviewRequestsGoodMomentsCount")
+            userDefaults.integer(forKey: Keys.reviewRequestsGoodMomentsCount)
         }
         set {
-            userDefaults.set(newValue, forKey: "reviewRequestsGoodMomentsCount")
+            userDefaults.set(newValue, forKey: Keys.reviewRequestsGoodMomentsCount)
         }
     }
     
     static var isHiddenFromMenuBar: Bool {
         get {
-            return userDefaults.bool(forKey: "isHiddenFromMenuBar")
+            userDefaults.bool(forKey: Keys.isHiddenFromMenuBar)
         }
         set {
-            userDefaults.set(newValue, forKey: "isHiddenFromMenuBar")
+            userDefaults.set(newValue, forKey: Keys.isHiddenFromMenuBar)
         }
     }
     


### PR DESCRIPTION
## Summary
- improve Defaults implementation
- extract bundle keys and clean up computed properties
- streamline String utilities and UserDefaults extensions

## Testing
- `swift -frontend -typecheck Shared/Services/Defaults.swift`
- `swift -frontend -typecheck Shared/Extensions/Bundle.swift`
- `swift -frontend -typecheck Shared/Extensions/String.swift`
- `swift -frontend -typecheck Shared/Extensions/UserDefaults.swift`
- `swift -frontend -typecheck Shared/Extensions/Image.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6846a4cb86f4832eb52dfa7a391530f9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored helper extensions and improved the Defaults implementation for cleaner, simpler code.

- **Refactors**
  - Centralized bundle keys and cleaned up computed properties.
  - Simplified String and UserDefaults extensions.
  - Updated Defaults to use key enums and clearer property access.

<!-- End of auto-generated description by cubic. -->

